### PR TITLE
chore(build): update emscripten setting

### DIFF
--- a/deps/dependee.json
+++ b/deps/dependee.json
@@ -53,7 +53,7 @@
         },
         "${target em}": {
             "ldflags": [
-                "-s USE_WEBGL2=1"
+                "-sMAX_WEBGL_VERSION=2"
             ],
             "${cfg debug}": {
                 "ldflags": [


### PR DESCRIPTION
USE_WEBGL2 is deprecated.

https://emscripten.org/docs/tools_reference/settings_reference.html#use-webgl2